### PR TITLE
Point Kamal at OVH VPS over Tailscale

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -4,11 +4,11 @@ image: laurentqro/agence-gare-monaco
 
 servers:
   web:
-    - 46.225.227.128
+    - 100.111.226.59
 
 proxy:
   ssl: true
-  host: curau.dev
+  host: dev.agencegaremonaco.com
 
 registry:
   server: ghcr.io
@@ -21,7 +21,7 @@ env:
     - RAILS_MASTER_KEY
   clear:
     SOLID_QUEUE_IN_PUMA: true
-    SITE_HOST: https://curau.dev
+    SITE_HOST: https://dev.agencegaremonaco.com
 
 aliases:
   console: app exec --interactive --reuse "bin/rails console"
@@ -36,5 +36,8 @@ volumes:
 asset_path: /rails/public/assets
 
 builder:
-  remote: ssh://root@46.225.227.128
+  remote: ssh://ubuntu@100.111.226.59
   arch: amd64
+
+ssh:
+  user: ubuntu


### PR DESCRIPTION
Migrate staging deploy target from the Hetzner VPS to the new hardened OVH VPS.

- `servers`/`builder` → tailnet IP `100.111.226.59` as user `ubuntu` (public SSH is closed on the OVH box; `ubuntu` is in the `docker` group so `PermitRootLogin no` stays intact)
- `proxy.host` and `SITE_HOST` → `dev.agencegaremonaco.com`

`SeoHelper#staging?` is an exact `SITE_HOST != PRODUCTION_HOST` check, so the new subdomain keeps staging behavior (noindex/nofollow, robots disallow, Plausible skipped) — verified live.

The data (SQLite volumes + tour files) was already migrated out-of-band and the app is serving `HTTP/2 200` at the new host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)